### PR TITLE
Document branch-first agent workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# Agent Instructions
+
+## Branch Policy
+
+- Do not work directly on `master` or `main` for normal feature work, bug fixes, or documentation changes.
+- Start every task on a short-lived branch unless the user explicitly says to work directly on the default branch.
+- Use clear branch names such as:
+  - `feature/waterfall-real-data`
+  - `bugfix/df-audio-audible`
+  - `docs/branch-policy`
+- Open a PR for review before merging whenever practical.
+
+## Exceptions
+
+- Direct work on `master` or `main` is only acceptable for urgent CI repair, release unblocking, or if the user explicitly asks for it.
+- If direct default-branch work is necessary, call that out in the final handoff and explain why it was an exception.
+
+## Verification
+
+- Before pushing, run the smallest relevant verification locally.
+- Preferred checks for this repo:
+  - `./testing/run_agent.sh`
+  - `./run_demo.sh --quit`
+
+## Documentation
+
+- Update agent-facing docs when workflow expectations change.
+- Keep `docs/workflow.md` and `docs/handoff.md` aligned with these instructions.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -36,6 +36,9 @@ The current build includes:
 5. Player-facing text should stay instructional, not diagnostic.
    Debug-heavy status output was replaced with simpler mission/status copy after user feedback.
 
+6. Branch-first workflow should be treated as standard operating procedure.
+   Future agents should start work on a short-lived branch and avoid direct `master` or `main` edits unless the user explicitly requests it or CI/release recovery requires it.
+
 ## Current files to know
 
 - `scripts/Main.gd`

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -2,15 +2,21 @@
 
 ## Branching
 
-For future work, prefer short-lived branches from the current baseline.
+For future work, use short-lived branches from the current baseline by default.
 
 Suggested pattern:
 
-- `main` or `master` stays runnable
+- `main` or `master` stays runnable and should not be used for day-to-day implementation work
 - Feature branches use names like:
   - `feature/waterfall-real-data`
   - `feature/hud-reflow`
   - `fix/reset-randomization`
+
+Required policy:
+
+- Start new work on a branch unless the user explicitly asks for direct default-branch changes.
+- Open a PR before merging whenever practical.
+- Treat direct `master` or `main` commits as exceptions for urgent CI or release repair only.
 
 ## Commit style
 


### PR DESCRIPTION
## Summary
- add a repo-local `AGENTS.md` with a branch-first policy
- update workflow notes to require short-lived branches by default
- update handoff notes so future agents inherit the same expectation

## Notes
Direct `master` or `main` changes are now documented as exceptions for urgent CI/release repair or explicit user requests.
