### PR TITLE
Publish rolling latest release from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         with:
           tag_name: prototype-latest
           name: Prototype Latest
-          prerelease: true
+          prerelease: false
           generate_release_notes: false
           make_latest: true
           body: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 - Fixed DF audio dropping during bearing capture and added an automated bearing-capture audio continuity test.
 - Refreshed the automated test baseline and rebuilt Linux, Windows, and HTML5 distribution artifacts.
 - Added GitHub Actions CI to run the headless test agent and export builds on push and pull request.
-- Updated GitHub Actions CI to publish a rolling `prototype-latest` prerelease with the latest build artifacts on pushes to `master` or `main`.
+- Updated GitHub Actions CI to publish a rolling `prototype-latest` release with the latest build artifacts on pushes to `master` or `main`.
+- Changed the rolling `prototype-latest` publication from a prerelease to a normal release so it becomes the visible latest GitHub release after each successful push.
 - Added automatic GitHub Pages deployment for the HTML5 build and linked the live demo in the README.
 - Fixed a DF receiver audio regression by making the DF player restart if playback stops on the active tuned source and by boosting the target conversation source gain.
 - Added automated DF audibility and DF restart regression cases to the headless testing agent.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ It exercises the real main scene, writes reports into `testing/reports/`, and co
 
 See [testing/README.md](/home/ein/projects/simple_game/testing/README.md) for coverage and report files.
 
-GitHub Actions CI is configured in [.github/workflows/ci.yml](/home/ein/projects/simple_game/.github/workflows/ci.yml) to run the headless test agent and export builds on push and pull request. Pushes to `master` or `main` also update a rolling GitHub prerelease named `Prototype Latest` with the built artifacts and deploy the HTML5 build to GitHub Pages.
+GitHub Actions CI is configured in [.github/workflows/ci.yml](/home/ein/projects/simple_game/.github/workflows/ci.yml) to run the headless test agent and export builds on push and pull request. Pushes to `master` or `main` also update a rolling GitHub release named `Prototype Latest` with the built artifacts and deploy the HTML5 build to GitHub Pages.
 
 ## Building distributables
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -67,4 +67,4 @@ Then open `http://localhost:8000`.
 
 - Export templates are installed on demand into the user Godot template directory.
 - The project uses `all_resources` export filtering so runtime-loaded map and audio assets are included in exported builds.
-- GitHub Actions publishes a rolling prerelease tagged `prototype-latest` on pushes to `master` or `main`, attaching the current Linux, Windows, and HTML5 build zips.
+- GitHub Actions publishes a rolling release tagged `prototype-latest` on pushes to `master` or `main`, attaching the current Linux, Windows, and HTML5 build zips.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -66,7 +66,7 @@ The current build includes:
   The headless testing agent now asserts that the DF path is actually audible on the target broadcast and that the DF player self-recovers if playback stops while the tuned broadcast remains unchanged.
 
 - `.github/workflows/ci.yml`
-  GitHub Actions pipeline that downloads the Godot runtime, runs the headless gameplay tests, builds export artifacts, updates a rolling `prototype-latest` GitHub prerelease, and deploys the HTML5 build to GitHub Pages on pushes to `master` or `main`.
+  GitHub Actions pipeline that downloads the Godot runtime, runs the headless gameplay tests, builds export artifacts, updates a rolling `prototype-latest` GitHub release, and deploys the HTML5 build to GitHub Pages on pushes to `master` or `main`.
 
 - `docs/architecture.md`
   High-level product/system architecture direction.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -39,7 +39,7 @@ timeout 3 ./run_demo.sh
 
 - Pushes to `master` or `main` trigger GitHub Actions CI.
 - CI runs the headless gameplay tests and export build.
-- If CI succeeds on `master` or `main`, GitHub updates the rolling prerelease tagged `prototype-latest` with the latest Linux, Windows, and HTML5 artifacts.
+- If CI succeeds on `master` or `main`, GitHub updates the rolling release tagged `prototype-latest` with the latest Linux, Windows, and HTML5 artifacts.
 - The same successful push also deploys the HTML5 build to GitHub Pages.
 
 ## Current baseline


### PR DESCRIPTION
## Summary
- change the rolling `prototype-latest` publication from prerelease to normal release
- keep `make_latest: true` so the automated release becomes the visible Latest release on GitHub
- update repo docs to match the new release behavior

## Why
The workflow was updating `prototype-latest`, but because it was marked as a prerelease GitHub kept showing the old manual `v0.1.0-prototype` release as the latest on the repo home page.
