### PR TITLE
Add repository trust and ownership files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @leeroywking

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+## Workflow
+
+- Start work from a short-lived branch.
+- Open a pull request against `master`.
+- Keep changes focused on one concern.
+- Run the smallest relevant local verification before pushing.
+
+Preferred verification commands:
+
+```bash
+./run_demo.sh --quit
+./testing/run_agent.sh
+./scripts/build_exports.sh
+```
+
+## Change Scope
+
+- Avoid mixing unrelated UI, signal-model, CI, and repo-maintenance changes in one PR.
+- Update documentation when behavior or workflow changes.
+- Do not commit generated runtime noise unless the file is intentionally tracked.
+
+## Review Notes
+
+PR descriptions should include:
+
+- what changed
+- why it changed
+- how it was verified
+- any known caveats
+
+## Assets And External Sources
+
+- Prefer assets with clear reuse terms.
+- Document source/provenance for newly added third-party assets or downloads.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright (c) 2026 Lee-Roy King
+
+All rights reserved.
+
+This repository and its contents are proprietary. No permission is granted to use,
+copy, modify, merge, publish, distribute, sublicense, or sell this software or its
+documentation without prior written permission from the copyright holder.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting A Vulnerability
+
+Please do not open public GitHub issues for security-sensitive reports.
+
+Report security concerns directly to the repository owner:
+
+- GitHub: `@leeroywking`
+
+When possible, include:
+
+- a short description of the issue
+- affected files or workflow areas
+- reproduction steps
+- impact assessment
+- any suggested mitigation
+
+## Scope
+
+Security reports are especially relevant for:
+
+- GitHub Actions and release automation
+- download/build scripts
+- secrets handling
+- authentication or webhook integrations
+
+## Response Expectations
+
+This is an active prototype repository, not a formally staffed product security program.
+Responses will be best-effort, but responsible reports are welcome.


### PR DESCRIPTION
## Summary
- add `LICENSE`, `SECURITY.md`, `CONTRIBUTING.md`, and `CODEOWNERS`
- establish explicit reuse, reporting, contribution, and ownership defaults

## Notes
The license in this PR is intentionally conservative: explicit all-rights-reserved rather than an open-source grant. That can be swapped later if you want different reuse terms.
