### PR TITLE
Add first-person can-antenna training mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+- Added `docs/first-person-can-antenna-plan.md` describing the first-person DF architecture, phases, and integration plan.
+- Added a first vertical slice of a first-person can-antenna mode using a low-resolution 3D viewport inside the existing 2D game.
+- Added a first-person heading model, simple can-antenna view model, and tactical inset map that shows captured lines of bearing.
+- Added a regression case covering first-person mode toggle behavior.
 - Fixed DF/scanner shared-broadcast playback so both receivers stay sample-aligned on the same conversation.
 - Added a deterministic regression test for DF/scanner shared-broadcast sync.
 - Added tracked `export_presets.cfg` for Linux, Windows, and HTML5 builds.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 - Added `docs/first-person-can-antenna-plan.md` describing the first-person DF architecture, phases, and integration plan.
 - Added a first vertical slice of a first-person can-antenna mode using a low-resolution 3D viewport inside the existing 2D game.
 - Added a first-person heading model, simple can-antenna view model, and tactical inset map that shows captured lines of bearing.
-- Added a regression case covering first-person mode toggle behavior.
+- Added in-view first-person reading overlays for heading, DF frequency, last reading, and step prompt text.
+- Added regression cases covering first-person mode toggle behavior and first-person reading capture.
 - Fixed DF/scanner shared-broadcast playback so both receivers stay sample-aligned on the same conversation.
 - Added a deterministic regression test for DF/scanner shared-broadcast sync.
 - Added tracked `export_presets.cfg` for Linux, Windows, and HTML5 builds.

--- a/docs/first-person-can-antenna-plan.md
+++ b/docs/first-person-can-antenna-plan.md
@@ -1,0 +1,280 @@
+# First-Person Can-Antenna Mode Plan
+
+## Goal
+
+Add a first-person direction-finding mode that teaches the player to:
+
+- sweep with a can antenna
+- read a lensatic compass heading while aimed
+- capture a line of bearing from first person
+- see that bearing recorded against map position
+
+This should extend the current trainer instead of replacing it.
+
+## Rendering Approach
+
+Do not bolt on a separate Doom engine.
+
+Use a Godot-native first-person module rendered through a low-resolution 3D `Viewport` and displayed inside the current 2D scene. That gives the right retro feel while preserving:
+
+- the existing RF / DF simulation
+- the current audio model
+- bearing capture logic
+- scanner logic
+- testing hooks
+- map-board plotting
+
+This keeps one game state, one set of broadcasts, and one source of truth for bearings.
+
+## Why This Architecture
+
+The current codebase is a 2D Godot 3 project with gameplay, UI, audio, and test hooks centered in `scripts/Main.gd`.
+
+The cleanest way to add first-person is:
+
+1. Keep the existing simulation authoritative.
+2. Add a first-person presentation layer on top of it.
+3. Translate player position and heading into a lightweight 3D scene.
+4. Reuse the same bearing capture and compass math.
+
+That avoids splitting the project into:
+
+- a top-down mode with one set of mechanics
+- a second standalone FPS prototype with duplicated logic
+
+## Recommended Structure
+
+### 1. Shared Simulation Layer
+
+Keep these systems shared:
+
+- player world position
+- heading / aim vector
+- DF tuning
+- scanner state
+- broadcast positions and frequencies
+- bearing capture data
+- score / submission logic
+
+This already exists and should stay authoritative.
+
+### 2. First-Person Presentation Layer
+
+Add a new first-person module that contains:
+
+- low-resolution 3D viewport
+- first-person camera
+- simple outdoor geometry
+- can-antenna view model
+- first-person HUD overlays
+
+This layer should never own core hunt logic.
+
+### 3. Reading Layer
+
+Add a focused "reading" UI for first-person work:
+
+- current compass heading
+- current DF frequency
+- current target/decoy status text
+- recent reading list
+- small tactical map inset with captured lines of bearing
+
+This becomes the bridge between first-person aiming and map-based fixing.
+
+## Input Model
+
+### Top-Down Mode
+
+Keep existing controls.
+
+### First-Person Mode
+
+Add:
+
+- `V`: toggle first-person view
+- mouse X: rotate heading
+- `Space`: capture reading / bearing
+
+For the first slice, mouse look only needs yaw. Pitch is unnecessary.
+
+## Data Flow
+
+1. Player moves in shared 2D world coordinates.
+2. First-person heading produces the same 2D aim vector used by DF logic.
+3. DF logic computes voice/noise/quality exactly as it does now.
+4. Bearing capture stores:
+   - origin
+   - direction
+   - azimuth
+   - quality
+   - frequency
+5. First-person inset map renders those stored bearings.
+6. Existing map board remains available for larger plotting.
+
+## Phase Breakdown
+
+### Phase 0: Planning And Seams
+
+Deliverables:
+
+- architecture doc
+- input plan
+- rendering approach decision
+
+### Phase 1: First-Person Vertical Slice
+
+Deliverables:
+
+- toggleable first-person mode
+- low-res 3D viewport
+- synced camera position and heading
+- can-antenna first-person model
+- live lensatic heading readout
+
+Success condition:
+
+- player can walk and aim in first person while hearing the same DF behavior as top-down
+
+### Phase 2: Bearing Reading Workflow
+
+Deliverables:
+
+- capture readings from first person
+- small tactical map inset
+- map origin marker and stored LOB lines
+- reading labels with azimuth and shot order
+
+Success condition:
+
+- player can take multiple first-person readings and see them accumulate spatially
+
+### Phase 3: Training Flow
+
+Deliverables:
+
+- focused prompts for:
+  - sweep
+  - settle
+  - read compass
+  - capture
+  - move
+  - capture again
+- less text, more stateful coaching
+
+Success condition:
+
+- the mode teaches one action at a time instead of dumping instructions
+
+### Phase 4: Rural / Tactical Upgrade
+
+Deliverables:
+
+- stronger terrain dressing
+- observation points
+- roads/trails/clearings
+- reduced UI assist
+- better close-in search behavior
+
+Success condition:
+
+- first-person DF feels like fieldwork instead of a camera gimmick
+
+### Phase 5: Full Integration
+
+Deliverables:
+
+- first-person and top-down share the same map-board workflow
+- submit/debrief supports readings captured in either mode
+- testing covers mode switching and reading capture
+
+Success condition:
+
+- first-person is a real part of the game loop, not a side demo
+
+## Integration Points In Current Code
+
+### `scripts/Main.gd`
+
+Primary integration file for first slice:
+
+- mode toggle state
+- first-person heading state
+- aim-vector switching
+- first-person viewport setup
+- tactical inset rendering
+- testing snapshot additions
+
+### `scenes/Main.tscn`
+
+Needs HUD additions for:
+
+- first-person viewport display
+- mode label
+- tactical inset map
+
+### `project.godot`
+
+Needs one new action:
+
+- `toggle_first_person`
+
+### `testing/agent/agent_runner.gd`
+
+Add first-person regression coverage for:
+
+- mode toggle
+- heading readout
+- first-person bearing capture state
+
+## Asset Strategy
+
+Do not wait on custom art.
+
+Use simple generated meshes first:
+
+- box terrain
+- cylinders / boxes for props
+- cylinder-based can antenna model
+
+This is enough to prove interaction before committing to a visual pass.
+
+## Risks
+
+### 1. Forked Logic
+
+If first-person starts owning separate DF logic, the project will become harder to maintain immediately.
+
+Mitigation:
+
+- keep shared simulation authoritative
+
+### 2. UI Clutter
+
+The current HUD is already dense.
+
+Mitigation:
+
+- first-person should use its own compact overlays rather than expanding the left panel further
+
+### 3. Godot 3 Complexity
+
+Adding 3D to a 2D scene increases setup cost.
+
+Mitigation:
+
+- keep the 3D scene minimal
+- render it through a viewport instead of restructuring the entire project into 3D
+
+## First Implementation Target
+
+The first coding slice should deliver:
+
+- `V` toggles first-person mode
+- camera heading drives DF aim
+- simple can antenna visible in first person
+- lensatic readout stays live
+- `Space` in first person records a bearing
+- small inset map shows player position plus captured LOBs
+
+That is the minimum feature set that proves this mode is worth continuing.

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -20,6 +20,8 @@ The current build includes:
 - A strongly directional DF audio model intended to feel closer to a narrow improvised directional antenna
 - Step-by-step training prompts that update as the player progresses through identify, capture, plot, and submit
 - A visible lensatic-style compass overlay that continuously shows the current DF heading
+- An initial first-person can-antenna mode rendered through a low-resolution 3D viewport
+- A tactical inset map in first-person mode that shows player position and captured LOBs
 - A short DF-audio hold during bearing capture so `Space` does not cut playback
 - DF and scanner playback stay time-aligned when both receivers are monitoring the same broadcast
 - Bearing capture now records azimuth and coaching text so players get explicit keep/retake guidance
@@ -85,6 +87,9 @@ The current build includes:
 - Training-and-visual guidance coverage
   The headless testing agent now checks tutorial-step progression, live compass heading, and labeled bearing-visual summaries.
 
+- First-person mode coverage
+  The headless testing agent now checks first-person mode toggle state and verifies heading continuity there.
+
 - `.github/workflows/ci.yml`
   GitHub Actions pipeline that downloads the Godot runtime, runs the headless gameplay tests, builds export artifacts, updates a rolling `prototype-latest` GitHub release, and publishes branch previews plus the default HTML5 build to GitHub Pages.
 
@@ -111,6 +116,7 @@ The current build includes:
 - Bearing capture now applies a short DF-audio hold so pressing `Space` does not cause a momentary audio drop if the receiver would otherwise flicker off the station during capture.
 - The map board is still not a full notebook workflow, but it is no longer just a zoomed view. It now supports direct fix placement on the board and shows bearings with azimuth notes and uncertainty wedges.
 - Reset now also resets DF tuning so a new run starts from a clean teaching state instead of inheriting the prior frequency.
+- First-person mode is a vertical slice, not a full replacement for the top-down workflow yet. It shares the simulation, but the environment dressing is intentionally minimal.
 
 ## Recommended next steps
 
@@ -118,6 +124,7 @@ The current build includes:
 2. Evolve the current fake-but-live waterfall into a truer receiver-band model or FFT-driven display.
 3. Add a stronger mission loop around identifying the target frequency before triangulation.
 4. Introduce terrain-aware attenuation only after the current interaction loop feels stable.
+5. Continue the first-person plan in `docs/first-person-can-antenna-plan.md`, especially the reading workflow and tactical/rural phases.
 
 ## Running the prototype
 

--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -22,6 +22,7 @@ The current build includes:
 - A visible lensatic-style compass overlay that continuously shows the current DF heading
 - An initial first-person can-antenna mode rendered through a low-resolution 3D viewport
 - A tactical inset map in first-person mode that shows player position and captured LOBs
+- First-person reading overlays that show live heading, DF frequency, last reading, and prompt text
 - A short DF-audio hold during bearing capture so `Space` does not cut playback
 - DF and scanner playback stay time-aligned when both receivers are monitoring the same broadcast
 - Bearing capture now records azimuth and coaching text so players get explicit keep/retake guidance
@@ -88,7 +89,7 @@ The current build includes:
   The headless testing agent now checks tutorial-step progression, live compass heading, and labeled bearing-visual summaries.
 
 - First-person mode coverage
-  The headless testing agent now checks first-person mode toggle state and verifies heading continuity there.
+  The headless testing agent now checks first-person mode toggle state, verifies heading continuity there, and validates first-person reading capture state.
 
 - `.github/workflows/ci.yml`
   GitHub Actions pipeline that downloads the Godot runtime, runs the headless gameplay tests, builds export artifacts, updates a rolling `prototype-latest` GitHub release, and publishes branch previews plus the default HTML5 build to GitHub Pages.

--- a/docs/prototype.md
+++ b/docs/prototype.md
@@ -83,6 +83,7 @@ The first-person can-antenna slice now exists as an alternate presentation mode:
 - mouse motion rotates the first-person heading
 - the same DF simulation and bearing capture logic remain authoritative
 - a small tactical inset map records player position and captured LOBs while in first person
+- a compact in-view overlay shows heading, DF frequency, last reading, and the active prompt
 - the 3D view is intentionally low-resolution and simple to preserve a retro training feel
 
 The prototype now includes a lightweight training flow instead of only a static welcome panel:

--- a/docs/prototype.md
+++ b/docs/prototype.md
@@ -22,6 +22,7 @@ It is not a full game. It is a proof of the key teaching interaction.
 - Map-board plotting aids including a north reference ring, bearing cards, uncertainty wedges, and board-side fix placement
 - Step-by-step training prompts that advance with the player’s progress
 - Lensatic-style compass overlay with live heading readout
+- Toggleable first-person can-antenna view rendered in-engine
 - Independent DF and scanner audio volume controls
 - Aim-quality feedback
 - Bearing coaching with azimuth readout and keep/retake guidance
@@ -76,6 +77,14 @@ The map board is now closer to a hand-plotting aid than a simple zoomed view:
 - Captured bearings are labeled in-world and on the map board so the shot location and angle stay visually linked
 - Left-clicking the board places the current estimated fix directly on the plotting surface
 
+The first-person can-antenna slice now exists as an alternate presentation mode:
+
+- `V` toggles first-person view
+- mouse motion rotates the first-person heading
+- the same DF simulation and bearing capture logic remain authoritative
+- a small tactical inset map records player position and captured LOBs while in first person
+- the 3D view is intentionally low-resolution and simple to preserve a retro training feel
+
 The prototype now includes a lightweight training flow instead of only a static welcome panel:
 
 - The welcome modal explains the purpose of the exercise briefly
@@ -97,6 +106,7 @@ The stated task for the player is:
 - `C`: toggle clean monitor
 - `F`: trigger scanner sweep or rescan
 - `M`: open or close the map board
+- `V`: toggle first-person can-antenna view
 
 ## Local launch
 

--- a/project.godot
+++ b/project.godot
@@ -97,6 +97,11 @@ toggle_map_board={
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":77,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
+toggle_first_person={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":86,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [rendering]
 

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -47,6 +47,23 @@ margin_bottom = 82.0
 text = "Reading Map"
 align = 1
 
+[node name="FirstPersonInfo" type="Label" parent="HUD/Root"]
+visible = false
+margin_left = 420.0
+margin_top = 606.0
+margin_right = 1000.0
+margin_bottom = 650.0
+text = "Heading / frequency / reading"
+
+[node name="FirstPersonPrompt" type="Label" parent="HUD/Root"]
+visible = false
+margin_left = 420.0
+margin_top = 648.0
+margin_right = 1000.0
+margin_bottom = 692.0
+text = "Prompt"
+autowrap = true
+
 [node name="WelcomeModal" type="ColorRect" parent="HUD/Root"]
 visible = true
 anchor_right = 1.0

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -12,6 +12,41 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
 
+[node name="FirstPersonView" type="TextureRect" parent="HUD/Root"]
+visible = false
+margin_left = 400.0
+margin_top = 40.0
+margin_right = 1240.0
+margin_bottom = 680.0
+expand = true
+stretch_mode = 6
+
+[node name="FirstPersonLabel" type="Label" parent="HUD/Root"]
+visible = false
+margin_left = 420.0
+margin_top = 50.0
+margin_right = 860.0
+margin_bottom = 74.0
+text = "First Person Can Antenna"
+
+[node name="FirstPersonMap" type="TextureRect" parent="HUD/Root"]
+visible = false
+margin_left = 1012.0
+margin_top = 82.0
+margin_right = 1228.0
+margin_bottom = 298.0
+expand = true
+stretch_mode = 6
+
+[node name="FirstPersonMapLabel" type="Label" parent="HUD/Root"]
+visible = false
+margin_left = 1012.0
+margin_top = 58.0
+margin_right = 1228.0
+margin_bottom = 82.0
+text = "Reading Map"
+align = 1
+
 [node name="WelcomeModal" type="ColorRect" parent="HUD/Root"]
 visible = true
 anchor_right = 1.0
@@ -41,7 +76,7 @@ margin_left = 24.0
 margin_top = 58.0
 margin_right = 516.0
 margin_bottom = 250.0
-text = "Purpose: learn to identify the real conversation, take clean bearings, and plot a usable fix.\n\nStep 1 starts after you close this panel:\nFind the real conversation and ignore the educational traffic.\n\nCore controls:\n- WASD move\n- Mouse aims the DF antenna\n- Type a frequency, drag the DF slider, or click the waterfall to tune\n- Space captures a bearing\n- M opens the map board"
+text = "Purpose: learn to identify the real conversation, take clean bearings, and plot a usable fix.\n\nStep 1 starts after you close this panel:\nFind the real conversation and ignore the educational traffic.\n\nCore controls:\n- WASD move\n- Mouse aims the DF antenna\n- Type a frequency, drag the DF slider, or click the waterfall to tune\n- Space captures a bearing\n- M opens the map board\n- V toggles first-person can-antenna view"
 autowrap = true
 
 [node name="WelcomeHint" type="Label" parent="HUD/Root/WelcomeModal/WelcomePanel"]
@@ -225,7 +260,7 @@ margin_left = 16.0
 margin_top = 640.0
 margin_right = 336.0
 margin_bottom = 692.0
-text = "Training step"
+text = "Training step\nV toggles first-person can-antenna view."
 autowrap = true
 
 [node name="SubmitButton" type="Button" parent="HUD/Root/Panel"]

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -15,6 +15,10 @@ const MAP_BOARD_RING_CENTER := Vector2(194, 218)
 const MAP_BOARD_RING_RADIUS := 92.0
 const COMPASS_CENTER := Vector2(1160, 618)
 const COMPASS_RADIUS := 66.0
+const FIRST_PERSON_VIEW_SIZE := Vector2(320, 180)
+const FIRST_PERSON_CAMERA_HEIGHT := 1.7
+const FIRST_PERSON_WORLD_SCALE := 0.03
+const FIRST_PERSON_MINIMAP_SIZE := 216
 const WA_HILLSHADE_PATH := "res://assets/maps/wa_hillshade.png"
 const STATIC_WAV_PATH := "res://assets/audio/static_noise.wav"
 const SCANNER_MIN_FREQ := 144.000
@@ -98,6 +102,12 @@ var waterfall_rows := []
 var broadcasts := []
 var map_texture = null
 var waterfall_texture = null
+var first_person_viewport = null
+var first_person_world_root = null
+var first_person_camera = null
+var first_person_ground = null
+var first_person_props := []
+var first_person_minimap_texture = null
 
 var df_voice_player = null
 var df_noise_player = null
@@ -108,6 +118,8 @@ var current_scanner_broadcast_id := ""
 
 var clean_monitor_enabled := false
 var map_board_visible := false
+var first_person_mode := false
+var first_person_heading_deg := 90.0
 var df_frequency := 145.000
 var df_volume := 0.85
 var scanner_volume := 0.70
@@ -166,6 +178,10 @@ onready var waterfall_display := $HUD/Root/Panel/WaterfallDisplay
 onready var map_board_overlay := $HUD/Root/MapBoardOverlay
 onready var map_board_status_label := $HUD/Root/MapBoardOverlay/MapBoardStatus
 onready var map_board_bearing_list := $HUD/Root/MapBoardOverlay/MapBoardBearingList
+onready var first_person_view := $HUD/Root/FirstPersonView
+onready var first_person_label := $HUD/Root/FirstPersonLabel
+onready var first_person_map := $HUD/Root/FirstPersonMap
+onready var first_person_map_label := $HUD/Root/FirstPersonMapLabel
 
 
 func _ready() -> void:
@@ -190,6 +206,7 @@ func _ready() -> void:
 	scanner_volume_slider.value = scanner_volume * 100.0
 	_sync_control_labels()
 	_sync_overlay_visibility()
+	_setup_first_person_view()
 	_setup_audio()
 	set_process(true)
 	set_physics_process(true)
@@ -219,22 +236,29 @@ func _process(delta: float) -> void:
 	_push_scope_sample(receiver_profile)
 	_push_waterfall_row(delta)
 	_update_waterfall_texture()
+	_update_first_person_view()
 	_update_status()
 	update()
 
 
 func _input(event: InputEvent) -> void:
 	if welcome_modal != null and welcome_modal.visible:
-		if event.is_action_pressed("submit_fix") or event.is_action_pressed("capture_bearing") or event.is_action_pressed("toggle_scanner") or event.is_action_pressed("reset_hunt") or event.is_action_pressed("toggle_clean_monitor"):
+		if event.is_action_pressed("submit_fix") or event.is_action_pressed("capture_bearing") or event.is_action_pressed("toggle_scanner") or event.is_action_pressed("reset_hunt") or event.is_action_pressed("toggle_clean_monitor") or event.is_action_pressed("toggle_first_person"):
 			_dismiss_welcome_modal()
 			get_tree().set_input_as_handled()
 			return
+	if first_person_mode and event is InputEventMouseMotion:
+		first_person_heading_deg = fmod(first_person_heading_deg + event.relative.x * 0.18 + 360.0, 360.0)
+		update()
+		return
 	if event.is_action_pressed("capture_bearing"):
 		_capture_bearing()
 	elif event.is_action_pressed("submit_fix"):
 		_submit_fix()
 	elif event.is_action_pressed("reset_hunt"):
 		_reset_hunt()
+	elif event.is_action_pressed("toggle_first_person"):
+		_toggle_first_person_mode()
 	elif event.is_action_pressed("toggle_clean_monitor"):
 		_toggle_clean_monitor()
 	elif event.is_action_pressed("toggle_scanner"):
@@ -250,7 +274,7 @@ func _input(event: InputEvent) -> void:
 		if waterfall_display != null and waterfall_display.get_global_rect().has_point(event.position):
 			_tune_df_to_waterfall_click(event.position)
 			return
-		if PLAY_AREA.has_point(event.position):
+		if not first_person_mode and PLAY_AREA.has_point(event.position):
 			fix_position = event.position
 			update()
 
@@ -259,6 +283,162 @@ func _dismiss_welcome_modal() -> void:
 	if welcome_modal != null:
 		welcome_modal.visible = false
 
+
+func _toggle_first_person_mode() -> void:
+	first_person_mode = not first_person_mode
+	if first_person_mode:
+		first_person_heading_deg = _bearing_degrees(_get_aim_vector())
+		result_text = "First-person can-antenna view enabled."
+	else:
+		result_text = "Returned to top-down view."
+	_sync_first_person_visibility()
+	update()
+
+
+func _setup_first_person_view() -> void:
+	first_person_viewport = Viewport.new()
+	first_person_viewport.name = "FirstPersonViewport"
+	first_person_viewport.disable_3d = false
+	first_person_viewport.render_target_update_mode = Viewport.UPDATE_ALWAYS
+	first_person_viewport.render_target_v_flip = true
+	first_person_viewport.size = FIRST_PERSON_VIEW_SIZE
+	add_child(first_person_viewport)
+
+	first_person_world_root = Spatial.new()
+	first_person_viewport.add_child(first_person_world_root)
+
+	var environment = Environment.new()
+	environment.background_mode = Environment.BG_COLOR
+	environment.background_color = Color(0.57, 0.67, 0.79)
+	environment.ambient_light_color = Color(0.72, 0.75, 0.70)
+	environment.ambient_light_energy = 0.55
+	var world_environment = WorldEnvironment.new()
+	world_environment.environment = environment
+	first_person_world_root.add_child(world_environment)
+
+	var sun = DirectionalLight.new()
+	sun.light_energy = 0.85
+	sun.rotation_degrees = Vector3(-54.0, -38.0, 0.0)
+	first_person_world_root.add_child(sun)
+
+	var ground_mesh = MeshInstance.new()
+	var ground_shape = CubeMesh.new()
+	ground_shape.size = Vector3(60.0, 0.1, 60.0)
+	ground_mesh.mesh = ground_shape
+	ground_mesh.translation = Vector3(0.0, -0.05, 0.0)
+	var ground_material = SpatialMaterial.new()
+	ground_material.albedo_color = Color(0.32, 0.39, 0.24)
+	ground_material.flags_unshaded = false
+	ground_mesh.material_override = ground_material
+	first_person_world_root.add_child(ground_mesh)
+	first_person_ground = ground_mesh
+
+	first_person_camera = Camera.new()
+	first_person_camera.current = true
+	first_person_camera.fov = 78.0
+	first_person_camera.near = 0.05
+	first_person_camera.far = 200.0
+	first_person_world_root.add_child(first_person_camera)
+
+	var rig = Spatial.new()
+	rig.translation = Vector3(0.28, -0.22, -0.58)
+	first_person_camera.add_child(rig)
+
+	var can_mesh = MeshInstance.new()
+	var can_shape = CylinderMesh.new()
+	can_shape.top_radius = 0.08
+	can_shape.bottom_radius = 0.11
+	can_shape.height = 0.46
+	can_mesh.mesh = can_shape
+	can_mesh.rotation_degrees = Vector3(88.0, 0.0, -18.0)
+	can_mesh.translation = Vector3(0.0, -0.08, 0.0)
+	var can_material = SpatialMaterial.new()
+	can_material.albedo_color = Color(0.80, 0.81, 0.76)
+	can_material.metallic = 0.2
+	can_mesh.material_override = can_material
+	rig.add_child(can_mesh)
+
+	var handle_mesh = MeshInstance.new()
+	var handle_shape = CubeMesh.new()
+	handle_shape.size = Vector3(0.06, 0.18, 0.06)
+	handle_mesh.mesh = handle_shape
+	handle_mesh.translation = Vector3(-0.02, -0.18, 0.08)
+	var handle_material = SpatialMaterial.new()
+	handle_material.albedo_color = Color(0.18, 0.14, 0.10)
+	handle_mesh.material_override = handle_material
+	rig.add_child(handle_mesh)
+
+	if first_person_view != null:
+		first_person_view.texture = first_person_viewport.get_texture()
+	_rebuild_first_person_props()
+	_sync_first_person_visibility()
+
+
+func _sync_first_person_visibility() -> void:
+	var visible = first_person_mode
+	if first_person_view != null:
+		first_person_view.visible = visible
+	if first_person_label != null:
+		first_person_label.visible = visible
+	if first_person_map != null:
+		first_person_map.visible = visible
+	if first_person_map_label != null:
+		first_person_map_label.visible = visible
+
+
+func _update_first_person_view() -> void:
+	if first_person_viewport == null or first_person_camera == null:
+		return
+	if not first_person_mode:
+		return
+	var fp_position = _world_to_first_person(player_position)
+	first_person_camera.translation = Vector3(fp_position.x, FIRST_PERSON_CAMERA_HEIGHT, fp_position.z)
+	var aim_vector = _get_aim_vector()
+	var forward = Vector3(aim_vector.x, 0.0, aim_vector.y)
+	first_person_camera.rotation = Vector3(0.0, atan2(-forward.x, -forward.z), 0.0)
+	_update_first_person_minimap()
+
+
+func _rebuild_first_person_props() -> void:
+	if first_person_world_root == null:
+		return
+	for prop in first_person_props:
+		if is_instance_valid(prop):
+			prop.queue_free()
+	first_person_props.clear()
+
+	var prop_positions := []
+	for broadcast in broadcasts:
+		prop_positions.append(broadcast["position"])
+	prop_positions.append(Vector2(PLAY_AREA.position.x + 120.0, PLAY_AREA.position.y + 140.0))
+	prop_positions.append(Vector2(PLAY_AREA.end.x - 180.0, PLAY_AREA.end.y - 120.0))
+	prop_positions.append(Vector2(PLAY_AREA.position.x + 240.0, PLAY_AREA.end.y - 160.0))
+	prop_positions.append(Vector2(PLAY_AREA.end.x - 280.0, PLAY_AREA.position.y + 180.0))
+
+	for index in range(prop_positions.size()):
+		var source_position = prop_positions[index]
+		var trunk = MeshInstance.new()
+		var trunk_shape = CubeMesh.new()
+		trunk_shape.size = Vector3(0.34, 1.6 + float(index % 3) * 0.5, 0.34)
+		trunk.mesh = trunk_shape
+		var fp_position = _world_to_first_person(source_position)
+		trunk.translation = Vector3(fp_position.x, trunk_shape.size.y * 0.5, fp_position.z)
+		var trunk_material = SpatialMaterial.new()
+		trunk_material.albedo_color = Color(0.25, 0.20, 0.14)
+		trunk.material_override = trunk_material
+		first_person_world_root.add_child(trunk)
+		first_person_props.append(trunk)
+
+		var crown = MeshInstance.new()
+		var crown_shape = CubeMesh.new()
+		crown_shape.size = Vector3(1.4, 1.1, 1.4)
+		crown.mesh = crown_shape
+		crown.translation = trunk.translation + Vector3(0.0, trunk_shape.size.y * 0.5 + 0.7, 0.0)
+		var crown_material = SpatialMaterial.new()
+		crown_material.albedo_color = Color(0.22, 0.34, 0.20)
+		crown.material_override = crown_material
+		first_person_world_root.add_child(crown)
+		first_person_props.append(crown)
 
 func _draw() -> void:
 	_draw_world()
@@ -451,6 +631,79 @@ func _world_point_from_map_board(board_position: Vector2) -> Vector2:
 	)
 
 
+func _world_to_first_person(world_position: Vector2) -> Vector3:
+	return Vector3(
+		(world_position.x - PLAY_AREA.position.x - PLAY_AREA.size.x * 0.5) * FIRST_PERSON_WORLD_SCALE,
+		0.0,
+		(world_position.y - PLAY_AREA.position.y - PLAY_AREA.size.y * 0.5) * FIRST_PERSON_WORLD_SCALE
+	)
+
+
+func _update_first_person_minimap() -> void:
+	if first_person_map == null:
+		return
+	var image = Image.new()
+	image.create(FIRST_PERSON_MINIMAP_SIZE, FIRST_PERSON_MINIMAP_SIZE, false, Image.FORMAT_RGBA8)
+	image.lock()
+	for y in range(FIRST_PERSON_MINIMAP_SIZE):
+		for x in range(FIRST_PERSON_MINIMAP_SIZE):
+			image.set_pixel(x, y, Color(0.07, 0.10, 0.10, 0.92))
+	for step in range(0, FIRST_PERSON_MINIMAP_SIZE, 36):
+		for x in range(FIRST_PERSON_MINIMAP_SIZE):
+			_set_image_pixel_safe(image, x, step, Color(0.28, 0.34, 0.30, 0.45))
+		for y in range(FIRST_PERSON_MINIMAP_SIZE):
+			_set_image_pixel_safe(image, step, y, Color(0.28, 0.34, 0.30, 0.45))
+	for bearing in bearings:
+		var origin = _world_to_minimap_point(bearing["origin"])
+		var end_point = _world_to_minimap_point(bearing["origin"] + bearing["direction"] * BEARING_LENGTH)
+		_draw_image_line(image, origin, end_point, Color(0.24, 0.72, 0.96, 0.92))
+		_draw_image_circle(image, origin, 3, Color(0.94, 0.98, 1.0, 1.0))
+	var player_marker = _world_to_minimap_point(player_position)
+	_draw_image_circle(image, player_marker, 4, Color(0.98, 0.92, 0.40, 1.0))
+	var heading_tip = player_marker + _get_aim_vector() * 16.0
+	_draw_image_line(image, player_marker, heading_tip, Color(0.98, 0.92, 0.40, 0.92))
+	image.unlock()
+	if first_person_minimap_texture == null:
+		first_person_minimap_texture = ImageTexture.new()
+	first_person_minimap_texture.create_from_image(image, 0)
+	first_person_map.texture = first_person_minimap_texture
+
+
+func _world_to_minimap_point(world_position: Vector2) -> Vector2:
+	var ratio_x = clamp((world_position.x - PLAY_AREA.position.x) / PLAY_AREA.size.x, 0.0, 1.0)
+	var ratio_y = clamp((world_position.y - PLAY_AREA.position.y) / PLAY_AREA.size.y, 0.0, 1.0)
+	return Vector2(
+		ratio_x * float(FIRST_PERSON_MINIMAP_SIZE - 1),
+		ratio_y * float(FIRST_PERSON_MINIMAP_SIZE - 1)
+	)
+
+
+func _draw_image_line(image: Image, from_point: Vector2, to_point: Vector2, color: Color) -> void:
+	var delta = to_point - from_point
+	var steps = int(max(abs(delta.x), abs(delta.y)))
+	if steps <= 0:
+		_set_image_pixel_safe(image, int(round(from_point.x)), int(round(from_point.y)), color)
+		return
+	for index in range(steps + 1):
+		var ratio = float(index) / float(steps)
+		var point = from_point.linear_interpolate(to_point, ratio)
+		_set_image_pixel_safe(image, int(round(point.x)), int(round(point.y)), color)
+
+
+func _draw_image_circle(image: Image, center: Vector2, radius: int, color: Color) -> void:
+	for y in range(-radius, radius + 1):
+		for x in range(-radius, radius + 1):
+			if x * x + y * y > radius * radius:
+				continue
+			_set_image_pixel_safe(image, int(round(center.x)) + x, int(round(center.y)) + y, color)
+
+
+func _set_image_pixel_safe(image: Image, x: int, y: int, color: Color) -> void:
+	if x < 0 or y < 0 or x >= FIRST_PERSON_MINIMAP_SIZE or y >= FIRST_PERSON_MINIMAP_SIZE:
+		return
+	image.set_pixel(x, y, color)
+
+
 func _draw_bearings() -> void:
 	var font = _ui_font()
 	for index in range(bearings.size()):
@@ -553,6 +806,7 @@ func _reset_hunt() -> void:
 	show_target = false
 	fix_position = null
 	map_board_visible = false
+	first_person_mode = false
 	smoothed_voice_level = 0.0
 	smoothed_noise_level = 1.0
 	df_frequency = 145.000
@@ -568,10 +822,12 @@ func _reset_hunt() -> void:
 	player_position = Vector2(520, 560)
 	_reset_broadcasts()
 	scanner_button.text = "Start Scan"
+	first_person_heading_deg = 90.0
 	if df_frequency_slider != null:
 		df_frequency_slider.value = df_frequency
 	_sync_control_labels()
 	_sync_overlay_visibility()
+	_sync_first_person_visibility()
 
 
 func _update_status() -> void:
@@ -591,9 +847,13 @@ func _update_status() -> void:
 		scanner_text = "Scanner sweeping."
 	elif scanner_profile["state"] == "locked":
 		scanner_text = "Scanner locked."
+	var mode_text = "Mode: map"
+	if first_person_mode:
+		mode_text = "Mode: first-person can antenna"
 	var lines := [
 		"Purpose: identify target traffic, take bearings, and plot a fix.",
 		training_step["title"],
+		mode_text,
 		"DF: %.3f MHz" % df_frequency,
 		scanner_text,
 		"Bearings: %d" % bearings.size(),
@@ -1035,6 +1295,9 @@ func _find_scanner_candidate(frequency: float) -> Dictionary:
 func _get_aim_vector() -> Vector2:
 	if testing_aim_override_enabled and testing_aim_direction.length() > 0.001:
 		return testing_aim_direction.normalized()
+	if first_person_mode:
+		var radians = deg2rad(first_person_heading_deg)
+		return Vector2(sin(radians), -cos(radians)).normalized()
 	var aim = get_viewport().get_mouse_position() - player_position
 	if aim.length() < 0.001:
 		return Vector2.RIGHT
@@ -1370,6 +1633,7 @@ func _reset_broadcasts() -> void:
 		used_positions.append(broadcast["position"])
 		used_frequencies.append(broadcast["frequency"])
 		broadcasts.append(broadcast)
+	_rebuild_first_person_props()
 
 
 func _random_broadcast_position(used_positions: Array) -> Vector2:
@@ -1449,6 +1713,10 @@ func testing_set_aim_direction(direction: Vector2) -> void:
 		return
 	testing_aim_override_enabled = true
 	testing_aim_direction = direction.normalized()
+
+
+func testing_toggle_first_person() -> void:
+	_toggle_first_person_mode()
 
 
 func testing_clear_aim_override() -> void:
@@ -1557,6 +1825,8 @@ func testing_snapshot() -> Dictionary:
 		"scanner_button_text": scanner_button.text if scanner_button != null else "",
 		"training_step": training_step.duplicate(true),
 		"compass_heading_deg": _bearing_degrees(_get_aim_vector()),
+		"first_person_mode": first_person_mode,
+		"first_person_heading_deg": first_person_heading_deg,
 		"last_bearing": last_bearing,
 		"broadcasts": testing_get_broadcasts(),
 		"waterfall_summary": waterfall_summary,

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -182,6 +182,8 @@ onready var first_person_view := $HUD/Root/FirstPersonView
 onready var first_person_label := $HUD/Root/FirstPersonLabel
 onready var first_person_map := $HUD/Root/FirstPersonMap
 onready var first_person_map_label := $HUD/Root/FirstPersonMapLabel
+onready var first_person_info := $HUD/Root/FirstPersonInfo
+onready var first_person_prompt := $HUD/Root/FirstPersonPrompt
 
 
 func _ready() -> void:
@@ -384,6 +386,10 @@ func _sync_first_person_visibility() -> void:
 		first_person_map.visible = visible
 	if first_person_map_label != null:
 		first_person_map_label.visible = visible
+	if first_person_info != null:
+		first_person_info.visible = visible
+	if first_person_prompt != null:
+		first_person_prompt.visible = visible
 
 
 func _update_first_person_view() -> void:
@@ -764,6 +770,7 @@ func _capture_bearing() -> void:
 		return
 	var aim_vector = _get_aim_vector()
 	var azimuth_deg = _bearing_degrees(aim_vector)
+	var shot_number = bearings.size() + 1
 	var previous_separation = 0.0
 	if not bearings.empty():
 		previous_separation = player_position.distance_to(bearings[bearings.size() - 1]["origin"])
@@ -775,12 +782,17 @@ func _capture_bearing() -> void:
 		"broadcast_id": reading["broadcast_id"],
 		"quality": reading["quality"],
 		"azimuth_deg": azimuth_deg,
+		"capture_mode": "first_person" if first_person_mode else "top_down",
+		"shot_number": shot_number,
 		"origin_separation": previous_separation,
 		"advice": advice
 	})
 	bearing_capture_audio_hold_timer = 0.35
 	bearing_capture_audio_hold_broadcast_id = reading["broadcast_id"]
-	result_text = "Bearing %03d deg captured. %s" % [int(round(azimuth_deg)) % 360, advice]
+	if first_person_mode:
+		result_text = "Reading B%d %03d deg captured. %s" % [shot_number, int(round(azimuth_deg)) % 360, advice]
+	else:
+		result_text = "Bearing %03d deg captured. %s" % [int(round(azimuth_deg)) % 360, advice]
 
 
 func _submit_fix() -> void:
@@ -864,6 +876,19 @@ func _update_status() -> void:
 		lines.append(result_text)
 	status_label.text = "\n".join(lines)
 	instructions_label.text = "%s\n%s" % [training_step["title"], training_step["detail"]]
+	if first_person_info != null:
+		var heading_text = "HDG %03d" % (int(round(_bearing_degrees(_get_aim_vector()))) % 360)
+		var last_reading_text = "No reading"
+		if not bearings.empty():
+			var last_bearing = bearings[bearings.size() - 1]
+			last_reading_text = "B%d %03d %s" % [
+				int(last_bearing.get("shot_number", bearings.size())),
+				int(round(float(last_bearing.get("azimuth_deg", 0.0)))) % 360,
+				String(last_bearing.get("quality", "poor")).capitalize()
+			]
+		first_person_info.text = "%s   DF %.3f MHz   %s" % [heading_text, df_frequency, last_reading_text]
+	if first_person_prompt != null:
+		first_person_prompt.text = training_step["detail"]
 	if map_board_status_label != null:
 		map_board_status_label.text = "DF %.3f MHz | Bearings %d | %s | Plot N-up" % [df_frequency, bearings.size(), fix_text]
 	if map_board_bearing_list != null:
@@ -1331,6 +1356,17 @@ func _bearing_capture_advice(quality: String, previous_separation: float) -> Str
 
 func _current_training_step() -> Dictionary:
 	var target_identified = receiver_profile["broadcast_id"] == TARGET_BROADCAST_ID or scanner_locked_broadcast_id == TARGET_BROADCAST_ID
+	var reading_word = "bearing"
+	var first_capture_title = "Step 2: Capture the first bearing"
+	var first_capture_detail = "Aim for the clearest heading, then press Space to mark a line of bearing."
+	var second_capture_title = "Step 3: Move and take a second bearing"
+	var second_capture_detail = "Walk to a new position before pressing Space again so the lines can cross."
+	if first_person_mode:
+		reading_word = "reading"
+		first_capture_title = "Step 2: Capture the first reading"
+		first_capture_detail = "Sweep with the can antenna, settle on the clearest heading, read the lensatic compass, then press Space for a reading."
+		second_capture_title = "Step 3: Move and take a second reading"
+		second_capture_detail = "Move to a new position, settle the antenna again, and take a second reading so the LOBs can cross."
 	if show_target:
 		return {
 			"id": "review_fix",
@@ -1346,20 +1382,20 @@ func _current_training_step() -> Dictionary:
 	if bearings.size() == 0:
 		return {
 			"id": "capture_first_bearing",
-			"title": "Step 2: Capture the first bearing",
-			"detail": "Aim for the clearest heading, then press Space to mark a line of bearing."
+			"title": first_capture_title,
+			"detail": first_capture_detail
 		}
 	if bearings.size() == 1:
 		return {
 			"id": "capture_second_bearing",
-			"title": "Step 3: Move and take a second bearing",
-			"detail": "Walk to a new position before pressing Space again so the lines can cross."
+			"title": second_capture_title,
+			"detail": second_capture_detail
 		}
 	if fix_position == null:
 		return {
 			"id": "plot_fix",
 			"title": "Step 4: Plot the fix on the map",
-			"detail": "Open the map board if needed, compare your marked lines, then click a fix point."
+			"detail": "Open the map board if needed, compare your marked %ss, then click a fix point." % reading_word
 		}
 	return {
 		"id": "submit_fix",
@@ -1827,6 +1863,8 @@ func testing_snapshot() -> Dictionary:
 		"compass_heading_deg": _bearing_degrees(_get_aim_vector()),
 		"first_person_mode": first_person_mode,
 		"first_person_heading_deg": first_person_heading_deg,
+		"first_person_info_text": first_person_info.text if first_person_info != null else "",
+		"first_person_prompt_text": first_person_prompt.text if first_person_prompt != null else "",
 		"last_bearing": last_bearing,
 		"broadcasts": testing_get_broadcasts(),
 		"waterfall_summary": waterfall_summary,

--- a/testing/agent/agent_runner.gd
+++ b/testing/agent/agent_runner.gd
@@ -45,6 +45,7 @@ func _run() -> void:
 		yield(_run_map_board_case(), "completed"),
 		yield(_run_map_board_plotting_case(), "completed"),
 		yield(_run_first_person_mode_case(), "completed"),
+		yield(_run_first_person_reading_case(), "completed"),
 		yield(_run_training_step_progression_case(), "completed"),
 		yield(_run_compass_heading_case(), "completed"),
 		yield(_run_bearing_visuals_case(), "completed"),
@@ -189,6 +190,40 @@ func _run_first_person_mode_case() -> Dictionary:
 			"opened_mode": opened.get("first_person_mode", null),
 			"aimed_heading": aimed.get("compass_heading_deg", null),
 			"closed_mode": closed.get("first_person_mode", null)
+		}
+	}
+
+
+func _run_first_person_reading_case() -> Dictionary:
+	game.testing_reset_hunt()
+	yield(_wait_seconds(0.1), "timeout")
+	var target = game.testing_find_broadcast(TARGET_ID)
+	var listen_position = target["position"] + Vector2(-140, 0)
+	game.testing_set_player_position(listen_position)
+	game.testing_set_df_frequency(target["frequency"])
+	game.testing_toggle_first_person()
+	game.testing_set_aim_direction(target["position"] - listen_position)
+	yield(_wait_seconds(0.2), "timeout")
+	game.testing_capture_bearing()
+	yield(_wait_seconds(0.05), "timeout")
+	var snapshot = game.testing_snapshot()
+	var last_bearing = snapshot.get("last_bearing", {})
+	var passed = bool(snapshot.get("first_person_mode", false)) \
+		and int(snapshot.get("bearings_count", 0)) >= 1 \
+		and String(last_bearing.get("capture_mode", "")) == "first_person" \
+		and String(snapshot.get("first_person_info_text", "")).find("HDG") >= 0 \
+		and String(snapshot.get("result_text", "")).find("Reading B1") >= 0
+	game.testing_toggle_first_person()
+	return {
+		"name": "first_person_reading",
+		"pass": passed,
+		"warning": false,
+		"details": {
+			"bearings_count": snapshot.get("bearings_count", null),
+			"capture_mode": last_bearing.get("capture_mode", null),
+			"result_text": snapshot.get("result_text", null),
+			"first_person_info_text": snapshot.get("first_person_info_text", null),
+			"first_person_prompt_text": snapshot.get("first_person_prompt_text", null)
 		}
 	}
 

--- a/testing/agent/agent_runner.gd
+++ b/testing/agent/agent_runner.gd
@@ -44,6 +44,7 @@ func _run() -> void:
 		yield(_run_welcome_modal_case(), "completed"),
 		yield(_run_map_board_case(), "completed"),
 		yield(_run_map_board_plotting_case(), "completed"),
+		yield(_run_first_person_mode_case(), "completed"),
 		yield(_run_training_step_progression_case(), "completed"),
 		yield(_run_compass_heading_case(), "completed"),
 		yield(_run_bearing_visuals_case(), "completed"),
@@ -159,6 +160,36 @@ func _run_map_board_plotting_case() -> Dictionary:
 		"pass": bool(snapshot.get("map_board_visible", false)) and bool(board.get("has_bearing_list", false)) and int(board.get("bearing_cards", 0)) >= 1 and int(board.get("wedge_count", 0)) >= 1 and bool(board.get("has_fix", false)),
 		"warning": false,
 		"details": board
+	}
+
+
+func _run_first_person_mode_case() -> Dictionary:
+	game.testing_reset_hunt()
+	yield(_wait_seconds(0.05), "timeout")
+	var before = game.testing_snapshot()
+	game.testing_toggle_first_person()
+	yield(_wait_seconds(0.05), "timeout")
+	var opened = game.testing_snapshot()
+	game.testing_set_aim_direction(Vector2.RIGHT)
+	yield(_wait_seconds(0.05), "timeout")
+	var aimed = game.testing_snapshot()
+	game.testing_toggle_first_person()
+	yield(_wait_seconds(0.05), "timeout")
+	var closed = game.testing_snapshot()
+	var passed = not bool(before.get("first_person_mode", true)) \
+		and bool(opened.get("first_person_mode", false)) \
+		and abs(float(aimed.get("compass_heading_deg", 0.0)) - 90.0) <= 1.0 \
+		and not bool(closed.get("first_person_mode", true))
+	return {
+		"name": "first_person_mode",
+		"pass": passed,
+		"warning": false,
+		"details": {
+			"before_mode": before.get("first_person_mode", null),
+			"opened_mode": opened.get("first_person_mode", null),
+			"aimed_heading": aimed.get("compass_heading_deg", null),
+			"closed_mode": closed.get("first_person_mode", null)
+		}
 	}
 
 


### PR DESCRIPTION
## Summary
- document the first-person can-antenna architecture and phased roadmap in `docs/first-person-can-antenna-plan.md`
- add a Godot-native low-resolution first-person mode rendered through a 3D viewport inside the current 2D trainer
- change first-person `WASD` to Doom-style movement relative to heading
- expand the hunt into a much larger scrolling world while keeping the overhead view window and player movement speed readable
- add broader terrain cues in first person using the Washington hillshade as a source for hills, ridges, and valleys
- reuse the existing DF simulation, scanner state, bearing capture logic, and map-board data instead of forking systems
- add first-person reading overlays for live heading, DF frequency, last reading, and the current training prompt
- add a tactical inset map in first person that shows player position and captured lines of bearing
- bump the feature branch version to `0.4.1`
- add regression coverage for first-person mode toggle and first-person reading capture

## Live Build
- Preview will appear here after CI finishes: https://leeroywking.github.io/radio_game/previews/feature/first-person-can-antenna-plan/

## What To Test
- press `V` to enter first-person can-antenna mode and confirm the main view switches to a low-res first-person perspective
- in first person, confirm `WASD` now moves like Doom rather than sliding along overhead-map axes
- confirm the overhead map now scrolls over a much larger world instead of fitting the whole hunt into one screen
- move the mouse left and right in first person and confirm the antenna heading and DF behavior change with it
- confirm the first-person overlay shows heading, DF frequency, last reading, and the current prompt without relying on the left HUD alone
- tune onto the real conversation, press `Space` in first person, and confirm the result text reports a `Reading` capture instead of only the old top-down bearing language
- confirm the inset map in first person shows your position and accumulates captured LOBs as you take readings
- switch back to top-down and confirm the same captured lines still exist in the shared map workflow

## Verification
- `./run_demo.sh --quit`
- `./testing/run_agent.sh`